### PR TITLE
Add degree as a default page attribute on Education Struct

### DIFF
--- a/lib/fb_graph2/struct/education.rb
+++ b/lib/fb_graph2/struct/education.rb
@@ -3,7 +3,7 @@ module FbGraph2
     class Education < Struct
       register_attributes(
         raw: [:type],
-        page: [:school, :year],
+        page: [:school, :year, :degree],
         pages: [:classes, :concentration]
       )
     end


### PR DESCRIPTION
Just a little pull request to add the missing degree attribute to the Education struct.