### PR TITLE
check for nil object

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>fb_graph2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>com.aptana.projects.webnature</nature>
+	</natures>
+</projectDescription>

--- a/lib/fb_graph2/node.rb
+++ b/lib/fb_graph2/node.rb
@@ -2,6 +2,8 @@ module FbGraph2
   class Node
     attr_accessor :id, :access_token, :raw_attributes
 
+    alias_method :identifier, :id
+    
     def self.inherited(klass)
       klass.send :include, AttributeAssigner
       FbGraph2.object_classes << klass

--- a/lib/fb_graph2/util.rb
+++ b/lib/fb_graph2/util.rb
@@ -3,7 +3,7 @@ module FbGraph2
     module_function
 
     def as_identifier(object)
-      if object.respond_to? :id
+      if !object.nil? && object.respond_to?(:id)
         object.id
       else
         object


### PR DESCRIPTION
Calling FbGraph2::User.me(access_token).friends I was getting the following error:

Called id for nil, which would mistakenly be 8 -- if you really wanted the id of nil, use object_id
/home/eric/.rvm/gems/ruby-2.1.5/gems/fb_graph2-0.4.4/lib/fb_graph2/util.rb:7:in `as_identifier'
/home/eric/.rvm/gems/ruby-2.1.5/gems/fb_graph2-0.4.4/lib/fb_graph2/node.rb:91:in `build_endpoint'
/home/eric/.rvm/gems/ruby-2.1.5/gems/fb_graph2-0.4.4/lib/fb_graph2/node.rb:60:in `block in get'
/home/eric/.rvm/gems/ruby-2.1.5/gems/fb_graph2-0.4.4/lib/fb_graph2/node.rb:107:in `handle_response'
/home/eric/.rvm/gems/ruby-2.1.5/gems/fb_graph2-0.4.4/lib/fb_graph2/node.rb:59:in `get'
/home/eric/.rvm/gems/ruby-2.1.5/gems/fb_graph2-0.4.4/lib/fb_graph2/node.rb:79:in `edge_for'
/home/eric/.rvm/gems/ruby-2.1.5/gems/fb_graph2-0.4.4/lib/fb_graph2/node.rb:33:in `edge'
/home/eric/.rvm/gems/ruby-2.1.5/gems/fb_graph2-0.4.4/lib/fb_graph2/edge/friends.rb:5:in `friends'

ruby -v 
ruby 2.1.5p273
rails -v 
Rails 3.2.20

I couldn't see any argument I should be passing to avoid this error and of course "nil" does repond to :id.

What do you think?