### PR TITLE
Update util.rb

### DIFF
--- a/lib/fb_graph2/util.rb
+++ b/lib/fb_graph2/util.rb
@@ -3,7 +3,7 @@ module FbGraph2
     module_function
 
     def as_identifier(object)
-      if object.respond_to? :id
+      if object and object.respond_to? :id
         object.id
       else
         object


### PR DESCRIPTION
Handle scenarios where object could be `nil`, and then break the app.

I don't exactly know if there are consequences for parts of the app, but this made the library work with my production app. Feedback welcome.

I kept getting the following error:

```
RuntimeErrorCalled id for nil, which would mistakenly be 8 -- if you really wanted the id of nil, use object_id
gems/fb_graph2-0.5.0/lib/fb_graph2/util.rb:7as_identifier
gems/fb_graph2-0.5.0/lib/fb_graph2/node.rb:92build_endpoint
gems/fb_graph2-0.5.0/lib/fb_graph2/node.rb:61block in get
gems/fb_graph2-0.5.0/lib/fb_graph2/node.rb:108handle_response
gems/fb_graph2-0.5.0/lib/fb_graph2/node.rb:60get
gems/fb_graph2-0.5.0/lib/fb_graph2/node.rb:24fetch
```

This commit fixes that if options[:edge_case] is nil.