### PR TITLE
fixed a bug where conversation messages are not being authenticated

### DIFF
--- a/lib/fb_graph2/edge/conversations.rb
+++ b/lib/fb_graph2/edge/conversations.rb
@@ -4,7 +4,7 @@ module FbGraph2
       def conversations(params = {})
         conversations = self.edge :conversations, params
         conversations.collect! do |conversation|
-          Conversation.new(conversation[:id], conversation).authenticate conversation[:access_token]
+          Conversation.new(conversation[:id], conversation).authenticate self.access_token
         end
       end
     end

--- a/lib/fb_graph2/edge/messages.rb
+++ b/lib/fb_graph2/edge/messages.rb
@@ -4,7 +4,7 @@ module FbGraph2
       def messages(params = {})
         messages = self.edge :messages, params
         messages.collect! do |message|
-          Message.new(message[:id], message).authenticate message[:access_token]
+          Message.new(message[:id], message).authenticate self.access_token
         end
       end
     end

--- a/spec/fb_graph2/edge/conversations_spec.rb
+++ b/spec/fb_graph2/edge/conversations_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe FbGraph2::Edge::Conversations do
+  context 'Conversations' do
+    let(:page) { FbGraph2::Page.new("page_id").authenticate('token') }
+
+    describe '#conversations' do
+      it 'should return an Array of authenticated FbGraph2::Conversation objects' do
+
+        conversations = mock_graph :get, 'page_id/conversations', 'page/conversations', access_token: 'token' do
+          page.conversations
+        end
+
+        conversations.each { |conversation| expect(conversation.access_token).to eq('token') }
+
+      end
+    end
+  end
+end

--- a/spec/fb_graph2/edge/messages_spec.rb
+++ b/spec/fb_graph2/edge/messages_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe FbGraph2::Edge::Messages do
+  context 'Messages' do
+    let(:conversation) { FbGraph2::Conversation.new("conversation_id").authenticate('token') }
+
+    describe '#messages' do
+      it 'should return an Array of authenticated FbGraph2::Message objects' do
+
+        messages = mock_graph :get, 'conversation_id/messages', 'conversation/messages', access_token: 'token' do
+          conversation.messages
+        end
+
+        expect(messages.first.access_token).to eq('token')
+
+      end
+    end
+  end
+end

--- a/spec/mock_json/conversation/messages.json
+++ b/spec/mock_json/conversation/messages.json
@@ -1,0 +1,33 @@
+{
+  "data": [
+    {
+      "id": "m_mid.1427484003966:6a7d41f350be02b202",
+      "created_time": "2015-03-27T19:20:04+0000",
+      "tags": {
+        "data": [
+          {"name": "inbox"},
+          {"name": "source:web"}
+        ]
+      },
+      "from": {
+        "name": "Bryan Brunetti",
+        "email": "123456\u0040facebook.com",
+        "id": "643757367"
+      },
+      "to": {
+        "data": [
+          {
+            "name": "Desk Three",
+            "email": "775794712516982\u0040facebook.com",
+            "id": "775794712516982"
+          }
+        ]
+      },
+      "message": "testing a message"
+    }
+  ],
+  "paging": {
+    "previous": "https:\/\/graph.facebook.com\/v2.0\/t_mid.1426199405718:7ed3d5c7813b41e484\/messages?limit=25&since=1427484004&__paging_token=enc_AdBRZAAMNJk6afsV9fngFvUvCruCFRtYbsQjQDUFCYEd4CHjwrXUD33IkK80S68qMg8IO8YWa5cZB5n8KbZBLbMQXZCPFOyYoobd2Ij11bvI6PywwAZDZD&__previous=1",
+    "next": "https:\/\/graph.facebook.com\/v2.0\/t_mid.1426199405718:7ed3d5c7813b41e484\/messages?limit=25&until=1426199405&__paging_token=enc_AdD0AeYOoGBAn90kScirgzHTxGTnZCBaHYH5fDk2ESd90FesTLZAas06iG6NqMjTecoIAzs20zsfL4fmREIkC1HD0nSZA6E9TqF1aju7UYRDh7GgAZDZD"
+  }
+}

--- a/spec/mock_json/page/conversations.json
+++ b/spec/mock_json/page/conversations.json
@@ -1,0 +1,152 @@
+{
+  "data":[
+    {
+      "message_count":4,
+      "id":"t_mid.1414517590484:4a52ecd944c0691a57",
+      "updated_time":"2015-03-27T19:13:37+0000",
+      "messages":{
+        "data":[
+          {
+            "id":"m_mid.1427483617197:8c924a0cf2ac0b3c24",
+            "created_time":"2015-03-27T19:13:37+0000",
+            "tags":{
+              "data":[
+                {
+                  "name":"inbox"
+                },
+                {
+                  "name":"source:web"
+                }
+              ]
+            },
+            "from":{
+              "name":"Bryan Brunetti",
+              "email":"123456\u0040facebook.com",
+              "id":"643757367"
+            },
+            "to":{
+              "data":[
+                {
+                  "name":"MJJ Designs",
+                  "email":"202484463134297\u0040facebook.com",
+                  "id":"202484463134297"
+                }
+              ]
+            },
+            "message":"Test Message"
+          },
+          {
+            "id":"m_mid.1414519282171:23add76eb638bec943",
+            "created_time":"2014-10-28T18:01:22+0000",
+            "tags":{
+              "data":[
+                {
+                  "name":"inbox"
+                },
+                {
+                  "name":"read"
+                },
+                {
+                  "name":"sent"
+                },
+                {
+                  "name":"source:web"
+                }
+              ]
+            },
+            "from":{
+              "name":"MJJ Designs",
+              "email":"202484463134297\u0040facebook.com",
+              "id":"202484463134297"
+            },
+            "to":{
+              "data":[
+                {
+                  "name":"Mike Jandreau",
+                  "email":"512920166\u0040facebook.com",
+                  "id":"512920166"
+                }
+              ]
+            },
+            "message":"Replying back with a hopeful reopen."
+          },
+          {
+            "id":"m_mid.1414519100772:3b7a73dc20d9d0bb46",
+            "created_time":"2014-10-28T17:58:20+0000",
+            "tags":{
+              "data":[
+                {
+                  "name":"inbox"
+                },
+                {
+                  "name":"read"
+                },
+                {
+                  "name":"sent"
+                },
+                {
+                  "name":"source:web"
+                }
+              ]
+            },
+            "from":{
+              "name":"MJJ Designs",
+              "email":"202484463134297\u0040facebook.com",
+              "id":"202484463134297"
+            },
+            "to":{
+              "data":[
+                {
+                  "name":"Mike Jandreau",
+                  "email":"512920166\u0040facebook.com",
+                  "id":"512920166"
+                }
+              ]
+            },
+            "message":"Replying back and resolving."
+          },
+          {
+            "id":"m_mid.1414517590484:4a52ecd944c0691a57",
+            "created_time":"2014-10-28T17:33:10+0000",
+            "tags":{
+              "data":[
+                {
+                  "name":"inbox"
+                },
+                {
+                  "name":"read"
+                },
+                {
+                  "name":"source:web"
+                }
+              ]
+            },
+            "from":{
+              "name":"Bryan Brunetti",
+              "email":"643757367\u0040facebook.com",
+              "id":"643757367"
+            },
+            "to":{
+              "data":[
+                {
+                  "name":"MJJ Designs",
+                  "email":"202484463134297\u0040facebook.com",
+                  "id":"202484463134297"
+                }
+              ]
+            },
+            "message":"Hello, I am testing a message."
+          }
+        ],
+        "paging":{
+          "previous":"https:\/\/graph.facebook.com\/v2.0\/t_mid.1414517590484:4a52ecd944c0691a57\/messages?limit=25&since=1427483617&__paging_token=enc_AdAUyfn3MU8FZB1vc7ZBfTsAB4yvvJPyeAc3PQh3pNXBxOo5yrj8LRprCYjOagSFXG63UIFG5f9Yp9heZCDpVfduwJAQXx2w77AkZAsZC9uBUACQkWQZDZD&__previous=1",
+          "next":"https:\/\/graph.facebook.com\/v2.0\/t_mid.1414517590484:4a52ecd944c0691a57\/messages?limit=25&until=1414517590&__paging_token=enc_AdB5RShUekeWj57vQTtM0Ad1VAfDvX8ia51FBXTOL4krk1NZB2mximxaHhKOd7hPqupZBuaD32mZCSuG324adXoh8zsZAxSDaQDxzEZCuj2r1XLNgrwZDZD"
+        }
+      }
+    }
+  ],
+  "paging":{
+    "previous":"https:\/\/graph.facebook.com\/v2.0\/202484463134297\/conversations?fields=messages,message_count&limit=100&since=1427483617&__paging_token=enc_AdBi2J3tFiiykxpWS3oAdtHA9sg2eAZCNDaSOLko4ma6xLygs674cSHPsGw3ZAaqAWCFwtpOMGgZAgvfxScJdvS0xgcgOtu0UG5iV53I0kUusJ9PgZDZD&__previous=1",
+    "next":"https:\/\/graph.facebook.com\/v2.0\/202484463134297\/conversations?fields=messages,message_count&limit=100&since=1426881131&until=1427483617&__paging_token=enc_AdBi2J3tFiiykxpWS3oAdtHA9sg2eAZCNDaSOLko4ma6xLygs674cSHPsGw3ZAaqAWCFwtpOMGgZAgvfxScJdvS0xgcgOtu0UG5iV53I0kUusJ9PgZDZD"
+  }
+}


### PR DESCRIPTION
The `conversations` and `messages` edges do not return an `access_token` property.
This will ensure they inherit the `access_token` of the parent nodes