### PR TITLE
Enable `reply!` method for FbGraph2

### DIFF
--- a/lib/fb_graph2/edge/comments.rb
+++ b/lib/fb_graph2/edge/comments.rb
@@ -23,6 +23,12 @@ module FbGraph2
         comment = self.post params, edge: :comments
         Comment.new(comment[:id], params.merge(comment)).authenticate self.access_token
       end
+      
+      def reply!(params = {})
+        comment_id = self.post params, edge: :comments
+        Comment.new(comment_id).authenticate self.access_token
+      end
+      
     end
   end
 end

--- a/lib/fb_graph2/node.rb
+++ b/lib/fb_graph2/node.rb
@@ -111,7 +111,7 @@ module FbGraph2
       _response_ = _response_.with_indifferent_access if _response_.respond_to? :with_indifferent_access
       case response.status
       when 200...300
-        if _response_.respond_to?(:include?) && _response_.include?(:success)
+        if _response_.respond_to?(:include?) && (!(_response_.is_a? String) && _response_.include?(:success))
           _response_[:success]
         else
           _response_


### PR DESCRIPTION
As mentioned here : https://github.com/nov/fb_graph2/issues/61#issuecomment-94351832
The way Gem is, it would work for API V2.1+
But API V2.0 should still have `Comment#reply!` hence added it.