### PR TITLE
fixes implicit conversion of symbol into integer error

### DIFF
--- a/lib/fb_graph2/attribute_assigner.rb
+++ b/lib/fb_graph2/attribute_assigner.rb
@@ -67,6 +67,8 @@ module FbGraph2
               end
             when :location
               Struct::Location.new raw
+            when :place
+              Place.new raw, {id: raw}
             when :page
               Page.new raw[:id], raw
             when :pages

--- a/lib/fb_graph2/photo.rb
+++ b/lib/fb_graph2/photo.rb
@@ -11,7 +11,7 @@ module FbGraph2
         :offset_y, :offset_x
       ],
       time: [:backdated_time, :created_time, :updated_time],
-      page: [:place],
+      place: [:place],
       profile: [:from],
       album: [:album],
       image_sources: [:images],


### PR DESCRIPTION
when publishing a photo to a page

`page.photo!({
	url: "https://image.jpg"
	place: 1234567898765432
})`

response was throwing an implicit conversion error because no place attribute was found