### PR TITLE
Add ability for Test Users to be friends

### DIFF
--- a/lib/fb_graph2/edge/test_users.rb
+++ b/lib/fb_graph2/edge/test_users.rb
@@ -4,14 +4,14 @@ module FbGraph2
       def test_users(params = {})
         users = self.edge :accounts, params, edge_scope: :'test-users'
         users.collect! do |user|
-          User.new(user[:id], user)
+          TestUser.new(user[:id], user)
         end
       end
 
       def test_user!(params = {})
         user = self.post params, edge: :accounts, edge_scope: :'test-users'
         params.delete(:access_token) # so as not to keep app token
-        User.new(user[:id], user.merge(params))
+        TestUser.new(user[:id], user.merge(params))
       end
     end
   end

--- a/lib/fb_graph2/test_user.rb
+++ b/lib/fb_graph2/test_user.rb
@@ -5,5 +5,10 @@ module FbGraph2
     register_attributes(
       raw: [:login_url, :password]
     )
+
+    def friend!(test_user)
+      self.post({}, edge: :friends, edge_scope: test_user.id)
+      test_user.post({}, edge: :friends, edge_scope: self.id)
+    end
   end
 end

--- a/lib/fb_graph2/test_user.rb
+++ b/lib/fb_graph2/test_user.rb
@@ -1,0 +1,9 @@
+require 'fb_graph2/user'
+
+module FbGraph2
+  class TestUser < User
+    register_attributes(
+      raw: [:login_url, :password]
+    )
+  end
+end

--- a/spec/fb_graph2/edge/test_users_spec.rb
+++ b/spec/fb_graph2/edge/test_users_spec.rb
@@ -5,26 +5,26 @@ describe FbGraph2::Edge::TestUsers do
     let(:app) { FbGraph2::App.app('app_token') }
 
     describe '#test_users' do
-      it 'should return an Array of FbGraph2::User with test_user token' do
+      it 'should return an Array of FbGraph2::TestUser with test_user token' do
         users = mock_graph :get, 'app/accounts/test-users', 'app/test_users', access_token: 'app_token' do
           app.test_users
         end
         users.should be_instance_of FbGraph2::Edge
         users.should_not be_blank
         users.each do |user|
-          user.should be_instance_of FbGraph2::User
+          user.should be_instance_of FbGraph2::TestUser
           user.access_token.should == 'test_user_token'
         end
       end
     end
 
     describe '#test_user!' do
-      it 'should create an Object of FbGraph2::User with test_user token' do
+      it 'should create an Object of FbGraph2::TestUser with test_user token' do
         permissions = %w[public_profile,email,user_friends].join(',')
         user = mock_graph :post, 'app/accounts/test-users', 'post/test_users', access_token: 'app_token', permissions: permissions do
           app.test_user!
         end
-        user.should be_instance_of FbGraph2::User
+        user.should be_instance_of FbGraph2::TestUser
         user.access_token.should == 'test_user_token'
       end
     end

--- a/spec/fb_graph2/test_user_spec.rb
+++ b/spec/fb_graph2/test_user_spec.rb
@@ -27,4 +27,14 @@ describe FbGraph2::TestUser do
       test_user.login_url.should == 'https://developers.facebook.com/checkpoint/test-user-login/106444709796298/'
     end
   end
+
+  describe '#friend!' do
+    let(:test_friend) { FbGraph2::TestUser.new('123456789') }
+
+    it 'should request and confirm the friendship for the given test user' do
+      mock_graph :post, "#{test_user.id}/friends/#{test_friend.id}", 'success_true', access_token: test_user.access_token
+      mock_graph :post, "#{test_friend.id}/friends/#{test_user.id}", 'success_true', access_token: test_friend.access_token
+      test_user.friend!(test_friend)
+    end
+  end
 end

--- a/spec/fb_graph2/test_user_spec.rb
+++ b/spec/fb_graph2/test_user_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe FbGraph2::TestUser do
+  let(:app) { FbGraph2::App.app('app_token') }
+
+  let(:test_user) do
+    permissions = %w[public_profile,email,user_friends].join(',')
+    mock_graph :post, 'app/accounts/test-users', 'post/test_users', access_token: 'app_token', permissions: permissions do
+      app.test_user!
+    end
+  end
+
+  describe '#access_token' do
+    it 'should provide the TestUser access token' do
+      test_user.access_token.should == 'test_user_token'
+    end
+  end
+
+  describe '#password' do
+    it 'should provide the new test user password' do
+      test_user.password.should == 'test_user_password'
+    end
+  end
+
+  describe '#login_url' do
+    it 'should provide the new test user login_url' do
+      test_user.login_url.should == 'https://developers.facebook.com/checkpoint/test-user-login/106444709796298/'
+    end
+  end
+end


### PR DESCRIPTION
I recently needed to create a network of test users that were friends with each other but it seemed there was not yet any functionality to do this. Is this patch something that is useful to merge back into your gem? 

I'm happy to make changes. I was unsure about the usage of `FbGraph2::TestUser.register_attributes`, especially in a sub-class, but it seems to work correctly. The `FbGraph2::TestUser#friend!` method also seems like it might follow existing conventions better as a `FbGraph2::Edge` module to be included in `FbGraph2::TestUser` but it does not seem like it should go in the existing `FbGraph2::Edge::Friends` mixin. I could move this to `FbGraph2::Edge::TestUserFriends`?

Thanks for your work!