### PR TITLE
Thread safety config for root_url and api_version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.2.2 # NOTE: 2.2.1 or lower aren't supported by activesupport 5.0, CI isn't needed for such legacy versions.
-  - 2.2.6
   - 2.3.3
   - 2.4.0
+  - 2.5.6
+  - 2.6.4

--- a/lib/fb_graph2.rb
+++ b/lib/fb_graph2.rb
@@ -6,8 +6,10 @@ require 'rack/oauth2'
 require 'patch/rack/oauth2/util'
 
 module FbGraph2
-  mattr_accessor :root_url, :api_version, :gem_version, :logger, :debugging, :_http_config_, :object_classes
+  mattr_accessor :gem_version, :logger, :debugging, :_http_config_, :object_classes
 
+  DEFAULT_ROOT_URL = 'https://graph.facebook.com'
+  DEFAULT_API_VERSION = 'v2.11'
   self.root_url = 'https://graph.facebook.com'
   self.api_version = 'v2.11'
   self.gem_version = File.read(File.join(__dir__, '../VERSION')).strip
@@ -15,6 +17,22 @@ module FbGraph2
   self.logger.progname = 'FbGraph2'
 
   class << self
+    def root_url
+      Thread.current['fb_graph2_root_url'] || DEFAULT_ROOT_URL
+    end
+
+    def root_url=(value)
+      Thread.current['fb_graph2_root_url'] = value
+    end
+
+    def api_version
+      Thread.current['fb_graph2_api_version'] || DEFAULT_API_VERSION
+    end
+
+    def api_version=(value)
+      Thread.current['fb_graph2_api_version'] = value
+    end
+
     def object_classes
       FbGraph2::Node.descendants
     end

--- a/lib/fb_graph2.rb
+++ b/lib/fb_graph2.rb
@@ -16,19 +16,19 @@ module FbGraph2
 
   class << self
     def root_url
-      Thread.current['fb_graph2_root_url'] || DEFAULT_ROOT_URL
+      ::Thread.current['fb_graph2_root_url'] || DEFAULT_ROOT_URL
     end
 
     def root_url=(value)
-      Thread.current['fb_graph2_root_url'] = value
+      ::Thread.current['fb_graph2_root_url'] = value
     end
 
     def api_version
-      Thread.current['fb_graph2_api_version'] || DEFAULT_API_VERSION
+      ::Thread.current['fb_graph2_api_version'] || DEFAULT_API_VERSION
     end
 
     def api_version=(value)
-      Thread.current['fb_graph2_api_version'] = value
+      ::Thread.current['fb_graph2_api_version'] = value
     end
 
     def object_classes

--- a/lib/fb_graph2.rb
+++ b/lib/fb_graph2.rb
@@ -10,8 +10,6 @@ module FbGraph2
 
   DEFAULT_ROOT_URL = 'https://graph.facebook.com'
   DEFAULT_API_VERSION = 'v2.11'
-  self.root_url = 'https://graph.facebook.com'
-  self.api_version = 'v2.11'
   self.gem_version = File.read(File.join(__dir__, '../VERSION')).strip
   self.logger = Logger.new(STDOUT)
   self.logger.progname = 'FbGraph2'


### PR DESCRIPTION
Hey, @nov 

When use api in several thread in sidekiq we've got an issue, that root_url and api_version are not thread safety

The most used case when we upload a video file with the graph-video.facebook.com and have to change root_url for a while.